### PR TITLE
Updates to contrib/{load_files,control_characters}

### DIFF
--- a/doc/zepl-contrib.txt
+++ b/doc/zepl-contrib.txt
@@ -120,7 +120,7 @@ Add the following code snippet to your |vimrc| to enable this extension.
 <
 Two key combinations are provided. Press |gzc| and a key (combination) to
 send the corresponding character to the terminal (e.g. |gzc<C-c>| sends
-Ctrl-C).
+Ctrl-C). <Esc> cancels sending a character.
 
 The default combination to switch to the window containing the REPL is
 |gz<TAB>|.

--- a/doc/zepl-contrib.txt
+++ b/doc/zepl-contrib.txt
@@ -74,9 +74,9 @@ Add the following code snippet to your |vimrc| to enable this extension.
 >
     runtime zepl/contrib/load_files.vim
 <
-By using the `load_file` key in 'b:repl_config', you can specify a command for
-zepl to insert the file name into, and then send to the REPL.  The command
-uses `%s` in place of the file name (see: |printf()|).
+By using the `load_file` key in 'b:repl_config' or 'g:repl_config', you can
+specify a command for zepl to insert the file name into, and then send to the
+REPL. The command uses `%s` in place of the file name (see: |printf()|).
 
 Examples:
 >
@@ -111,39 +111,31 @@ Examples:
 ------------------------------------------------------------------------------
                                                       *zepl-control_characters*
 
-You might want to be able to send control characters such as newline, Ctrl-c,
-or Ctrl-d to your REPL.
+You might want to be able to send characters to your REPL, such as newline,
+Ctrl-C, Ctrl-D, or any others.
 
 Add the following code snippet to your |vimrc| to enable this extension.
 >
     runtime zepl/contrib/control_characters.vim
 <
-Three key combinations for sending special characters are also provided:
-|gz<CR>| to send a newline, |gzc| to send Ctrl-c (SIGINT), and |gzq| to send
-Ctrl-d (eof).
+Two key combinations are provided. Press |gzc| and a key (combination) to
+send the corresponding character to the terminal (e.g. |gzc<C-c>| sends
+Ctrl-C).
 
 The default combination to switch to the window containing the REPL is
 |gz<TAB>|.
 
-Four |<Plug>| mappings are also provided:
+Two |<Plug>| mappings are also provided:
 
-  * |<Plug>ReplSendNewline| sends a newline (<CR>) to the REPL.
+  * |<Plug>ReplSendKey| listens for a key (combination) to send.
 >
-    nmap <silent> <leader>s<CR> <Plug>ReplSendNewline
-<
-  * |<Plug>ReplSendCtrlC| sends Ctrl-C (SIGINT) to the REPL.
->
-    nmap <silent> <leader>sc <Plug>ReplSendCtrlC
-<
-  * |<Plug>ReplSendCtrlD| sends Ctrl-D (end-of-file) to the REPL.
->
-    nmap <silent> <leader>sd <Plug>ReplSendCtrlD
+    nmap <silent> gzc <Plug>ReplSendKey
 <
   * |<Plug>ReplFocus| moves the cursor to the window in the tab containing the
     REPL. If the REPL is not currently opened in a window, a new split window
     is created.
 >
-    nmap <silent> <leader>s<TAB> <Plug>ReplFocus
+    nmap <silent> gz<TAB> <Plug>ReplFocus
 <
 Note: You will likely want to disable zepl.vim's default key bindings before
 setting your own.  This can be done using 'g:zepl_default_maps'.

--- a/zepl/contrib/control_characters.vim
+++ b/zepl/contrib/control_characters.vim
@@ -1,4 +1,4 @@
-" Description:  Send control characters to the REPL and easily focus it.
+" Description:  Send characters to the REPL and easily focus it.
 " File:         zepl/contrib/control_characters.vim
 " Help:         :help zepl-control_characters
 " Legal:        No rights reserved.  Public domain.
@@ -9,19 +9,21 @@ function! s:jump_also_to_tab() abort
   call zepl#jump()
   let &switchbuf=swb
 endfunction
-
-command! -nargs=0 ReplSendNewline call zepl#send("\u0d", 1)
-command! -nargs=0 ReplSendCtrlC call zepl#send("\u03", 1)
-command! -nargs=0 ReplSendCtrlD call zepl#send("\u04", 1)
 command! -nargs=0 ReplFocus call s:jump_also_to_tab()
-nnoremap <silent> <Plug>ReplSendNewline :<C-u>ReplSendNewline<CR>
-nnoremap <silent> <Plug>ReplSendCtrlC :<C-u>ReplSendCtrlC<CR>
-nnoremap <silent> <Plug>ReplSendCtrlD :<C-u>ReplSendCtrlD<CR>
 nnoremap <silent> <Plug>ReplFocus :<C-u>ReplFocus<CR>
 
+function! s:send_key() abort
+  " Get a single key
+  let key = getchar()
+  " If the key wasn't escape, send it to the REPL
+  if key !=# 27
+    call zepl#send(nr2char(key), 1)
+  endif
+endfunction
+command! -nargs=0 ReplSendKey call s:send_key()
+nnoremap <silent> <Plug>ReplSendKey :<C-u>ReplSendKey<CR>
+
 if get(g:, 'zepl_default_maps', 1)
-  nmap <silent> gz<CR> <Plug>ReplSendNewline
-  nmap <silent> gzc <Plug>ReplSendCtrlC
-  nmap <silent> gzq <Plug>ReplSendCtrlD
+  nmap <silent> gzc <Plug>ReplSendKey
   nmap <silent> gz<TAB> <Plug>ReplFocus
 endif

--- a/zepl/contrib/load_files.vim
+++ b/zepl/contrib/load_files.vim
@@ -5,28 +5,15 @@
 
 function! zepl#contrib#load_files#load(...) abort
     " The dictionary entry identifying the command to laod a file
-    let loader_cmd_varname = 'load_file'
-
-    " Check buffer-local config, then global config
-    if exists('b:repl_config') && has_key(b:repl_config, &filetype)
-      let config_entry = b:repl_config[&filetype]
-    elseif exists('g:repl_config') && has_key(g:repl_config, &filetype)
-      let config_entry = g:repl_config[&filetype]
+    let load_cmd = zepl#config('load_file', '')
+    if empty(load_cmd)
+      echoerr "Could not load file(s) into REPL.  No value for 'load_file' set in Zepl configuration.  See ':help zepl-load_files' for more details."
     else
-      echoerr 'Neither b:repl_config nor g:repl_config has a definition for the filetype "'.&filetype.'"'
-      return
-    endif
-
-    if has_key(config_entry, loader_cmd_varname)
-      let load_cmd = config_entry[loader_cmd_varname]
-
       let fns = (a:0 > 0 ? a:000 : [expand('%')])
       let fns = map(copy(fns), 'fnamemodify(expand(v:val), ":p")')
       " let fns = filter(uniq(copy(fns)), 'filereadable(v:val)')
       let cmds = map(copy(fns), 'printf(load_cmd, v:val)')
       call zepl#send(cmds)
-    else
-      echoerr 'Neither b:repl_config nor g:repl_config has "load_file" defined.'
     endif
 endfunction
 

--- a/zepl/contrib/load_files.vim
+++ b/zepl/contrib/load_files.vim
@@ -4,11 +4,30 @@
 " Legal:        No rights reserved.  Public domain.
 
 function! zepl#contrib#load_files#load(...) abort
-    let fns = (a:0 > 0 ? a:000 : [expand('%')])
-    let fns = map(copy(fns), 'fnamemodify(expand(v:val), ":p")')
-    " let fns = filter(uniq(copy(fns)), 'filereadable(v:val)')
-    let cmds = map(copy(fns), 'printf(b:repl_config["load_file"], v:val)')
-    call zepl#send(cmds)
+    " The dictionary entry identifying the command to laod a file
+    let loader_cmd_varname = 'load_file'
+
+    " Check buffer-local config, then global config
+    if exists('b:repl_config') && has_key(b:repl_config, &filetype)
+      let config_entry = b:repl_config[&filetype]
+    elseif exists('g:repl_config') && has_key(g:repl_config, &filetype)
+      let config_entry = g:repl_config[&filetype]
+    else
+      echoerr 'Neither b:repl_config nor g:repl_config has a definition for the filetype "'.&filetype.'"'
+      return
+    endif
+
+    if has_key(config_entry, loader_cmd_varname)
+      let load_cmd = config_entry[loader_cmd_varname]
+
+      let fns = (a:0 > 0 ? a:000 : [expand('%')])
+      let fns = map(copy(fns), 'fnamemodify(expand(v:val), ":p")')
+      " let fns = filter(uniq(copy(fns)), 'filereadable(v:val)')
+      let cmds = map(copy(fns), 'printf(load_cmd, v:val)')
+      call zepl#send(cmds)
+    else
+      echoerr 'Neither b:repl_config nor g:repl_config has "load_file" defined.'
+    endif
 endfunction
 
 command! -nargs=* -complete=file -bar ReplLoadFile :call zepl#contrib#load_files#load(<f-args>)


### PR DESCRIPTION
I made updates to two contrib files:

* `load_files.vim`: previously, only `b:repl_config` was checked for a `load_file` definition, I think it's better if the global variable is also checked (with buffer-local taking priority). Also some error checking on whether the required keys are present in the dictionaries.

* `control_characters.vim`: I created a generic "send key" mapping, replacing the individual character mappings. That way to send any character, you just type `gzc` and then the character (such as ctrl-c). Pressing escape cancels sending a character.

I also updated the documentation accordingly.